### PR TITLE
Only show error if cache key exists and forgetCachedPermissions fail

### DIFF
--- a/src/Commands/CacheReset.php
+++ b/src/Commands/CacheReset.php
@@ -13,8 +13,13 @@ class CacheReset extends Command
 
     public function handle()
     {
-        app(PermissionRegistrar::class)->forgetCachedPermissions();
-        
-        $this->info('Permission cache flushed successfully.');
+        $permissionRegistrar = app(PermissionRegistrar::class);
+        $cacheExists = $permissionRegistrar->getCacheRepository()->has($permissionRegistrar->cacheKey);
+
+        if ($permissionRegistrar->forgetCachedPermissions()) {
+            $this->info('Permission cache flushed.');
+        } else if ($cacheExists) {
+            $this->error('Unable to flush cache.');
+        }
     }
 }


### PR DESCRIPTION
Another approach

I think that the error message should not be deleted,
it would be better to check if the cache exists, and whether to show the error only if the cache existed initially